### PR TITLE
Add chat-driven contract flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -252,8 +252,20 @@ def contract_service(service_id):
         contract_id = contract_ref[1].id
         data["contract_id"] = contract_id
         update_realtime_db(f"contracts/{contract_id}", data)
-        flash("Service contracted successfully!", "success")
-        return redirect(url_for("all_drones"))
+
+        # create a chat between the client and the drone owner
+        service = db.collection("services").document(service_id).get().to_dict()
+        drone = db.collection("drones").document(service["drone_id"]).get().to_dict()
+        chat_ref = db.collection("chats").add({
+            "contract_id": contract_id,
+            "owner_id": drone.get("owner_id"),
+            "client_id": session["user_id"],
+            "created_at": datetime.utcnow()
+        })
+        chat_id = chat_ref[1].id
+
+        flash("Service requested. You can chat with the owner now.", "success")
+        return redirect(url_for("chat", chat_id=chat_id))
 
     service_doc = db.collection("services").document(service_id).get()
     service = service_doc.to_dict()
@@ -736,9 +748,131 @@ def cancel_contract(contract_id):
     return redirect(url_for("my_contracts"))
 
 
+@app.route("/my_chats")
+def my_chats():
+    if "user_id" not in session:
+        return redirect(url_for("login"))
+
+    seen = set()
+    chats = []
+    for field in ("client_id", "owner_id"):
+        docs = db.collection("chats").where(field, "==", session["user_id"]).stream()
+        for d in docs:
+            if d.id in seen:
+                continue
+            seen.add(d.id)
+            data = d.to_dict()
+            contract = db.collection("contracts").document(data["contract_id"]).get().to_dict() or {}
+            service = db.collection("services").document(contract.get("service_id", "")).get().to_dict() or {}
+            owner = db.collection("users").document(data["owner_id"]).get().to_dict() or {}
+            client = db.collection("users").document(data["client_id"]).get().to_dict() or {}
+            chats.append({
+                "chat_id": d.id,
+                "service_name": service.get("service_name", "Service"),
+                "owner_name": owner.get("user_name", "Owner"),
+                "client_name": client.get("user_name", "Client"),
+                "status": contract.get("status", "pending")
+            })
+
+    return render_template("my_chats.html", chats=chats)
 
 
 
+
+
+
+@app.route("/open_chat/<contract_id>")
+def open_chat(contract_id):
+    if "user_id" not in session:
+        return redirect(url_for("login"))
+
+    contract_doc = db.collection("contracts").document(contract_id).get()
+    if not contract_doc.exists:
+        flash("Contract not found.", "danger")
+        return redirect(url_for("dashboard"))
+
+    contract = contract_doc.to_dict()
+    service = db.collection("services").document(contract["service_id"]).get().to_dict()
+    drone = db.collection("drones").document(service["drone_id"]).get().to_dict()
+
+    owner_id = drone.get("owner_id")
+    client_id = contract.get("user_id")
+
+    if session["user_id"] not in (owner_id, client_id):
+        flash("Unauthorized access.", "danger")
+        return redirect(url_for("dashboard"))
+
+    chats = list(db.collection("chats").where("contract_id", "==", contract_id).limit(1).stream())
+    if chats:
+        chat_id = chats[0].id
+    else:
+        chat_ref = db.collection("chats").add({
+            "contract_id": contract_id,
+            "owner_id": owner_id,
+            "client_id": client_id,
+            "created_at": datetime.utcnow()
+        })
+        chat_id = chat_ref[1].id
+
+    return redirect(url_for("chat", chat_id=chat_id))
+
+@app.route("/chat/<chat_id>", methods=["GET", "POST"])
+def chat(chat_id):
+    if "user_id" not in session:
+        return redirect(url_for("login"))
+
+    chat_ref = db.collection("chats").document(chat_id)
+    chat_doc = chat_ref.get()
+    if not chat_doc.exists:
+        flash("Chat not found.", "danger")
+        return redirect(url_for("dashboard"))
+
+    chat_data = chat_doc.to_dict()
+    if session["user_id"] not in (chat_data.get("owner_id"), chat_data.get("client_id")):
+        flash("Unauthorized access.", "danger")
+        return redirect(url_for("dashboard"))
+
+    contract_ref = db.collection("contracts").document(chat_data["contract_id"])
+    contract_snapshot = contract_ref.get()
+    contract = contract_snapshot.to_dict() if contract_snapshot.exists else {}
+
+    if request.method == "POST":
+        action = request.form.get("action")
+        if action == "accept" and session["user_id"] == chat_data.get("owner_id") and contract.get("status") == "pending":
+            contract_ref.update({"status": "confirmed"})
+            flash("Contract approved.", "success")
+        elif action == "reject" and session["user_id"] == chat_data.get("owner_id") and contract.get("status") == "pending":
+            contract_ref.update({"status": "cancelled"})
+            flash("Contract rejected.", "warning")
+        else:
+            message = request.form.get("message", "").strip()
+            if message:
+                chat_ref.collection("messages").add({
+                    "sender_id": session["user_id"],
+                    "content": message,
+                    "timestamp": datetime.utcnow()
+                })
+        return redirect(url_for("chat", chat_id=chat_id))
+
+    messages_query = chat_ref.collection("messages").order_by("timestamp").stream()
+    messages = [m.to_dict() | {"is_me": m.to_dict().get("sender_id") == session["user_id"]} for m in messages_query]
+
+    owner_doc = db.collection("users").document(chat_data["owner_id"]).get()
+    client_doc = db.collection("users").document(chat_data["client_id"]).get()
+    user_names = {
+        chat_data["owner_id"]: owner_doc.to_dict().get("user_name", "Owner") if owner_doc.exists else "Owner",
+        chat_data["client_id"]: client_doc.to_dict().get("user_name", "Client") if client_doc.exists else "Client"
+    }
+
+    return render_template(
+        "chat.html",
+        messages=messages,
+        chat_id=chat_id,
+        user_names=user_names,
+        contract=contract,
+        is_owner=session["user_id"] == chat_data.get("owner_id"),
+        user_id=session["user_id"]
+    )
 @app.route("/logout")
 def logout():
     session.clear()

--- a/readme.md
+++ b/readme.md
@@ -41,3 +41,4 @@ VALUES (1, 'Savannah Scout', 'AirTrack', 'HD', 1.0, 20, -1.2921, 36.8219);
 -- Sydney, Australia
 INSERT INTO drones (owner_id, model, manufacturer, camera_quality, max_load, flight_time, latitude, longitude)
 VALUES (1, 'Outback Flyer', 'AussieDrones', '4K', 2.3, 33, -33.8688, 151.2093);
+\n-When a service is requested a chat is automatically opened between the client and the drone owner. The owner can accept or reject the contract directly from the chat.

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,8 +21,7 @@
                 <div class="navbar-nav">
                     <a href="{{ url_for('dashboard') }}" class="nav-link text-white">Home</a>
                     <a href="{{ url_for('all_drones') }}" class="nav-link text-white">All Drones</a>
-                    <a href="{{ url_for('my_contracts') }}" class="nav-link text-white">My Contracts</a>
-                    <a href="{{ url_for('my_requests') }}" class="nav-link text-white">Service Requests</a>
+                    <a href="{{ url_for('my_chats') }}" class="nav-link text-white">Chats</a>
                     <a href="{{ url_for('search_drones') }}" class="nav-link text-white">Search Drones</a>
                     <a href="{{ url_for('drone_map') }}" class="nav-link text-white">Map</a>
                     <a href="{{ url_for('logout') }}" class="btn btn-danger ms-lg-3 mt-2 mt-lg-0">Logout</a>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block title %}Chat{% endblock %}
+{% block content %}
+<h2>Chat</h2>
+<div class="mb-3">
+    <strong>Status:</strong>
+    {% if contract.status == 'pending' %}
+        <span class="badge bg-warning text-dark">Pending</span>
+    {% elif contract.status == 'confirmed' %}
+        <span class="badge bg-success">Confirmed</span>
+    {% elif contract.status == 'cancelled' %}
+        <span class="badge bg-danger">Cancelled</span>
+    {% endif %}
+    {% if is_owner and contract.status == 'pending' %}
+        <form method="POST" class="d-inline">
+            <input type="hidden" name="action" value="accept">
+            <button class="btn btn-sm btn-success">Accept</button>
+        </form>
+        <form method="POST" class="d-inline ms-2">
+            <input type="hidden" name="action" value="reject">
+            <button class="btn btn-sm btn-danger">Reject</button>
+        </form>
+    {% endif %}
+</div>
+<div class="mb-4 border p-3 bg-white" style="max-height:400px; overflow-y:auto;">
+    {% for m in messages %}
+        <div class="mb-2 {% if m.is_me %}text-end{% endif %}">
+            <strong>{{ user_names.get(m.sender_id, 'User') }}:</strong>
+            {{ m.content }}
+            <small class="text-muted">{{ m.timestamp }}</small>
+        </div>
+    {% endfor %}
+</div>
+<form method="POST" class="input-group">
+    <input type="text" name="message" class="form-control" placeholder="Type a message" required>
+    <button class="btn btn-primary" type="submit">Send</button>
+</form>
+{% endblock %}

--- a/templates/my_chats.html
+++ b/templates/my_chats.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}My Chats{% endblock %}
+{% block content %}
+<h2>My Chats</h2>
+{% if chats %}
+<div class="table-responsive mt-4">
+<table class="table table-bordered table-striped">
+<thead class="table-light">
+<tr><th>Service</th><th>Owner</th><th>Client</th><th>Status</th><th></th></tr>
+</thead>
+<tbody>
+{% for c in chats %}
+<tr>
+<td>{{ c.service_name }}</td>
+<td>{{ c.owner_name }}</td>
+<td>{{ c.client_name }}</td>
+<td>{{ c.status }}</td>
+<td><a href="{{ url_for('chat', chat_id=c.chat_id) }}" class="btn btn-sm btn-primary">Open</a></td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+</div>
+{% else %}
+<div class="alert alert-info mt-4">No chats yet.</div>
+{% endif %}
+{% endblock %}

--- a/templates/my_contracts.html
+++ b/templates/my_contracts.html
@@ -38,6 +38,7 @@
                     <td>
                         {% if c.get("status") == 'pending' %}
                             <span class="badge bg-warning text-dark">Pending</span>
+                            <a href="{{ url_for('open_chat', contract_id=c['contract_id']) }}" class="btn btn-sm btn-outline-primary mt-2">Chat</a>
                             <a href="{{ url_for('cancel_contract', contract_id=c['contract_id']) }}"
                                class="btn btn-sm btn-outline-danger mt-2"
                                onclick="return confirm('Are you sure you want to cancel this contract?');">
@@ -52,6 +53,7 @@
                                    Acceder al servicio
                                 </a>
                             {% endif %}
+                            <a href="{{ url_for('open_chat', contract_id=c['contract_id']) }}" class="btn btn-sm btn-outline-primary mt-2">Chat</a>
                             <a href="{{ url_for('cancel_contract', contract_id=c['contract_id']) }}"
                                class="btn btn-sm btn-outline-danger mt-2"
                                onclick="return confirm('Are you sure you want to cancel this contract?');">

--- a/templates/my_requests.html
+++ b/templates/my_requests.html
@@ -39,7 +39,10 @@
                     <td>
                         {% if r["status"] == 'pending' %}
                             <a href="{{ url_for('approve_request', contract_id=r['contract_id']) }}" class="btn btn-sm btn-success me-2">Approve</a>
-                            <a href="{{ url_for('reject_request', contract_id=r['contract_id']) }}" class="btn btn-sm btn-outline-danger">Reject</a>
+                            <a href="{{ url_for('reject_request', contract_id=r['contract_id']) }}" class="btn btn-sm btn-outline-danger me-2">Reject</a>
+                            <a href="{{ url_for('open_chat', contract_id=r['contract_id']) }}" class="btn btn-sm btn-outline-primary">Chat</a>
+                        {% elif r["status"] == 'confirmed' %}
+                            <a href="{{ url_for('open_chat', contract_id=r['contract_id']) }}" class="btn btn-sm btn-outline-primary">Chat</a>
                         {% else %}
                             <span class="text-muted">No action</span>
                         {% endif %}


### PR DESCRIPTION
## Summary
- automatically start a chat when requesting a service
- manage contract status (accept/reject) from the chat
- list all chats via new `my_chats` route and page
- simplify navigation to use chats instead of contracts/requests

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846dab2c5f8832fbfe39c8358ea22be