### PR TITLE
Update landing page media

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,8 @@ app = Flask(__name__)
 app.secret_key = "supersecretkey"
 
 # Optional YouTube video for the landing page
-YOUTUBE_VIDEO_ID = os.environ.get("YOUTUBE_VIDEO_ID", "21bFvPk7Ddk")
+# Default to AnyDrone promotional video if not provided via environment
+YOUTUBE_VIDEO_ID = os.environ.get("YOUTUBE_VIDEO_ID", "uyYmYpCOeD8")
 
 # --- Firebase Init ---
 firebase_json = os.environ.get("FIREBASE_KEY")

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,15 +34,21 @@
     </div>
 </div>
 
-<div class="row text-center my-5">
-    <div class="col-md-4 mb-4">
-        <img src="https://images.unsplash.com/photo-1556761175-129418cb2dfe?auto=format&fit=crop&w=600&q=60" class="img-fluid rounded shadow-sm" alt="Drone inspecting tower">
+<div class="row text-center my-5 gallery">
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_fuego.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone apagando fuego">
     </div>
-    <div class="col-md-4 mb-4">
-        <img src="https://images.unsplash.com/photo-1508614999368-9260051291ea?auto=format&fit=crop&w=600&q=60" class="img-fluid rounded shadow-sm" alt="Drone delivering package">
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_limpia.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone de limpieza">
     </div>
-    <div class="col-md-4 mb-4">
-        <img src="https://images.unsplash.com/photo-1506956191993-eab1e19447f4?auto=format&fit=crop&w=600&q=60" class="img-fluid rounded shadow-sm" alt="Drone surveying fields">
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_fumigador.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone fumigador">
+    </div>
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_botiquin.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone botiquín">
+    </div>
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_reparto.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone de reparto">
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- show new drone images in the landing page gallery
- embed new promotional YouTube video by default

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852e51fcc94832fbf4e9f9ea1c02de9