### PR TITLE
Use dark style for login buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,8 @@ app = Flask(__name__)
 app.secret_key = "supersecretkey"
 
 # Optional YouTube video for the landing page
-YOUTUBE_VIDEO_ID = os.environ.get("YOUTUBE_VIDEO_ID", "21bFvPk7Ddk")
+# Default to AnyDrone promotional video if not provided via environment
+YOUTUBE_VIDEO_ID = os.environ.get("YOUTUBE_VIDEO_ID", "uyYmYpCOeD8")
 
 # --- Firebase Init ---
 firebase_json = os.environ.get("FIREBASE_KEY")

--- a/static/style.css
+++ b/static/style.css
@@ -181,7 +181,7 @@ input[type="datetime-local"] {
 
 /* Landing Page */
 .hero {
-    background-image: url('https://images.unsplash.com/photo-1495567720989-cebdbdd97913?auto=format&fit=crop&w=1500&q=60');
+    background-image: url('../images/dron_limpia.jpeg');
     background-size: cover;
     background-position: center;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 {% block title %}AnyDrone{% endblock %}
 {% block content %}
-<div class="hero text-white text-center py-5 mb-4 rounded">
-    <h1 class="display-4 fw-bold">Welcome to AnyDrone</h1>
-    <p class="lead">Monitor and contract drone services in real time.</p>
-    <a href="{{ url_for('login') }}" class="btn btn-outline-light btn-lg m-2">Login</a>
-    <a href="{{ url_for('register') }}" class="btn btn-success btn-lg m-2">Register</a>
+<div class="hero text-center py-5 mb-4 rounded">
+    <h1 class="display-4 fw-bold text-white">Welcome to AnyDrone</h1>
+    <p class="lead text-dark">Monitor and contract drone services in real time.</p>
+    <a href="{{ url_for('login') }}" class="btn btn-dark btn-lg m-2">Login</a>
+    <a href="{{ url_for('register') }}" class="btn btn-dark btn-lg m-2">Register</a>
 </div>
 
 <div class="row align-items-center mb-5">
     <div class="col-md-6">
-        <img src="https://images.unsplash.com/photo-1504196606672-aef5c9cefc92?auto=format&fit=crop&w=800&q=60" class="img-fluid rounded shadow" alt="Drone in flight">
+        <img src="{{ url_for('static', filename='images/dron_reparto.jpeg') }}" class="img-fluid rounded shadow" alt="Delivery drone">
 
     </div>
     <div class="col-md-6">
@@ -34,15 +34,21 @@
     </div>
 </div>
 
-<div class="row text-center my-5">
-    <div class="col-md-4 mb-4">
-        <img src="https://images.unsplash.com/photo-1556761175-129418cb2dfe?auto=format&fit=crop&w=600&q=60" class="img-fluid rounded shadow-sm" alt="Drone inspecting tower">
+<div class="row text-center my-5 gallery">
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_fuego.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone apagando fuego">
     </div>
-    <div class="col-md-4 mb-4">
-        <img src="https://images.unsplash.com/photo-1508614999368-9260051291ea?auto=format&fit=crop&w=600&q=60" class="img-fluid rounded shadow-sm" alt="Drone delivering package">
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_limpia.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone de limpieza">
     </div>
-    <div class="col-md-4 mb-4">
-        <img src="https://images.unsplash.com/photo-1506956191993-eab1e19447f4?auto=format&fit=crop&w=600&q=60" class="img-fluid rounded shadow-sm" alt="Drone surveying fields">
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_fumigador.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone fumigador">
+    </div>
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_botiquin.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone botiquín">
+    </div>
+    <div class="col mb-4">
+        <img src="{{ url_for('static', filename='images/dron_reparto.jpeg') }}" class="img-fluid rounded shadow-sm" alt="Drone de reparto">
     </div>
 </div>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,7 +12,7 @@
                 <label>Password</label>
                 <input type="password" name="password" class="form-control" required>
             </div>
-    <button type="submit" class="btn btn-primary w-100">Login</button>
+    <button type="submit" class="btn btn-dark w-100">Login</button>
 </form>
 <p class="text-center mt-3">Don't have an account? <a href="{{ url_for('register') }}">Register</a></p>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -22,7 +22,7 @@
                     He leído y acepto los <a href="{{ url_for('terms') }}" target="_blank">Términos y Condiciones</a>.
                 </label>
             </div>
-    <button type="submit" class="btn btn-success w-100">Register</button>
+    <button type="submit" class="btn btn-dark w-100">Register</button>
 </form>
 <p class="text-center mt-3">Already have an account? <a href="{{ url_for('login') }}">Login</a></p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- update hero login/register buttons to black
- set hero tagline text to black
- use black buttons on login and registration forms

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852e51fcc94832fbf4e9f9ea1c02de9