### PR TITLE
Implement live chat notification badge

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -54,5 +54,31 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    function fetchUnread() {
+        fetch("{{ url_for('unread_count') }}")
+            .then(r => r.json())
+            .then(d => {
+                const link = document.querySelector("a[href='{{ url_for('my_chats') }}']");
+                if (!link) return;
+                let badge = link.querySelector('.badge');
+                if (d.count > 0) {
+                    if (!badge) {
+                        badge = document.createElement('span');
+                        badge.className = 'position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger';
+                        link.appendChild(badge);
+                    }
+                    badge.textContent = d.count;
+                } else if (badge) {
+                    badge.remove();
+                }
+            })
+            .catch(console.error);
+    }
+    document.addEventListener('DOMContentLoaded', function () {
+        setInterval(fetchUnread, 10000);
+    });
+</script>
+{% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/unread_count` endpoint to check unread chats
- display unread chat badge dynamically on navigation bar
- expose `scripts` block in `base.html`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c4f0b17ac832fa80df0e16ce0c61e