### PR TITLE
Hide logout button when not logged in

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -19,20 +19,31 @@
     
             <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
                 <div class="navbar-nav">
-                    <a href="{{ url_for('dashboard') }}" class="nav-link text-white">Home</a>
+                    {% if session.get('user_id') %}
+                        <a href="{{ url_for('dashboard') }}" class="nav-link text-white">Home</a>
+                    {% else %}
+                        <a href="{{ url_for('home') }}" class="nav-link text-white">Home</a>
+                    {% endif %}
                     <a href="{{ url_for('all_drones') }}" class="nav-link text-white">All Drones</a>
-                    <a href="{{ url_for('my_chats') }}" class="nav-link text-white position-relative">
-                        Chats
-                        {% if unread_chats %}
-                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
-                                {{ unread_chats }}
-                            </span>
-                        {% endif %}
-                    </a>
+                    {% if session.get('user_id') %}
+                        <a href="{{ url_for('my_chats') }}" class="nav-link text-white position-relative">
+                            Chats
+                            {% if unread_chats %}
+                                <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+                                    {{ unread_chats }}
+                                </span>
+                            {% endif %}
+                        </a>
+                    {% endif %}
 
                     <a href="{{ url_for('search_drones') }}" class="nav-link text-white">Search Drones</a>
                     <a href="{{ url_for('drone_map') }}" class="nav-link text-white">Map</a>
-                    <a href="{{ url_for('logout') }}" class="btn btn-danger ms-lg-3 mt-2 mt-lg-0">Logout</a>
+                    {% if session.get('user_id') %}
+                        <a href="{{ url_for('logout') }}" class="btn btn-danger ms-lg-3 mt-2 mt-lg-0">Logout</a>
+                    {% else %}
+                        <a href="{{ url_for('login') }}" class="nav-link text-white">Login</a>
+                        <a href="{{ url_for('register') }}" class="nav-link text-white">Register</a>
+                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- update base template navbar to show login and register links when the user is not logged in
- only show logout and chats when a session is active

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py -h` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685c546f2160832f9cf64b8376dda838